### PR TITLE
feat: Add scroll-to-top button

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -8,6 +8,7 @@ import { Analytics } from "@vercel/analytics/react";
 import Footer from "@/components/footer";
 import JsonLd from "@/components/json-ld";
 import Navigation from "@/components/navigation";
+import ScrollToTopButton from "@/components/ScrollToTopButton";
 
 export const metadata: Metadata = {
   metadataBase: new URL(process.env.BASE_URL || "http://localhost:3000"),
@@ -106,6 +107,7 @@ export default function RootLayout({
             {children}
           </div>
           <Footer />
+          <ScrollToTopButton />
         </ThemeProvider>
         <Analytics />
       </body>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -102,6 +102,7 @@ export default function RootLayout({
           enableSystem
           disableTransitionOnChange
         >
+          <div id="scroll-visibility-target" style={{ position: 'absolute', top: '400px' }}></div>
           <div className="container px-6 py-6">
             <Navigation />
             {children}

--- a/src/components/ScrollToTopButton.tsx
+++ b/src/components/ScrollToTopButton.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+const ScrollToTopButton = () => {
+  const [isVisible, setIsVisible] = useState(false);
+
+  const toggleVisibility = () => {
+    if (window.scrollY > 400) {
+      setIsVisible(true);
+    } else {
+      setIsVisible(false);
+    }
+  };
+
+  const scrollToTop = () => {
+    window.scrollTo({
+      top: 0,
+      behavior: "smooth",
+    });
+  };
+
+  useEffect(() => {
+    window.addEventListener("scroll", toggleVisibility);
+
+    return () => {
+      window.removeEventListener("scroll", toggleVisibility);
+    };
+  }, []);
+
+  if (!isVisible) {
+    return null;
+  }
+
+  return (
+    <button
+      onClick={scrollToTop}
+      className="fixed bottom-4 right-4 rounded-full bg-gray-800 p-3 text-white shadow-lg transition-all duration-300 ease-in-out hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-gray-500 focus:ring-opacity-50 md:bottom-8 md:right-8"
+    >
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        fill="none"
+        viewBox="0 0 24 24"
+        strokeWidth={1.5}
+        stroke="currentColor"
+        className="h-6 w-6"
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          d="M4.5 15.75l7.5-7.5 7.5 7.5"
+        />
+      </svg>
+    </button>
+  );
+};
+
+export default ScrollToTopButton;

--- a/src/components/ScrollToTopButton.tsx
+++ b/src/components/ScrollToTopButton.tsx
@@ -1,17 +1,62 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useState, useRef } from "react";
 
 const ScrollToTopButton = () => {
   const [isVisible, setIsVisible] = useState(false);
+  const [isFooterIntersecting, setIsFooterIntersecting] = useState(false);
+  const [footerHeight, setFooterHeight] = useState(0);
+  const footerRef = useRef<HTMLElement | null>(null);
 
-  const toggleVisibility = () => {
-    if (window.scrollY > 400) {
-      setIsVisible(true);
-    } else {
-      setIsVisible(false);
+  const adjustmentMargin = 16; // 1rem, space between button and footer
+
+  // Effect for showing/hiding the button based on scroll position
+  useEffect(() => {
+    const toggleVisibility = () => {
+      if (window.scrollY > 400) {
+        setIsVisible(true);
+      } else {
+        setIsVisible(false);
+      }
+    };
+
+    window.addEventListener("scroll", toggleVisibility);
+    return () => window.removeEventListener("scroll", toggleVisibility);
+  }, []);
+
+  // Effect for IntersectionObserver to detect footer visibility
+  useEffect(() => {
+    // Assign footerRef.current here, after component mounts
+    footerRef.current = document.getElementById("site-footer");
+
+    if (!footerRef.current) {
+      console.warn("ScrollToTopButton: Footer element #site-footer not found.");
+      return; // Do not proceed if footer element is not found
     }
-  };
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        setIsFooterIntersecting(entry.isIntersecting);
+        if (entry.isIntersecting) {
+          // Ensure footerRef.current is available before accessing offsetHeight
+          setFooterHeight(footerRef.current?.offsetHeight || 0);
+        }
+      },
+      {
+        // Triggers when the top of the footer is 60px from the bottom of the viewport.
+        rootMargin: "0px 0px 60px 0px", // top right bottom left
+      }
+    );
+
+    observer.observe(footerRef.current);
+
+    return () => {
+      if (footerRef.current) {
+        observer.unobserve(footerRef.current);
+      }
+      observer.disconnect();
+    };
+  }, []); // Empty dependency array ensures this runs once on mount and cleans up on unmount
 
   const scrollToTop = () => {
     window.scrollTo({
@@ -20,23 +65,37 @@ const ScrollToTopButton = () => {
     });
   };
 
-  useEffect(() => {
-    window.addEventListener("scroll", toggleVisibility);
-
-    return () => {
-      window.removeEventListener("scroll", toggleVisibility);
-    };
-  }, []);
-
   if (!isVisible) {
     return null;
   }
 
+  // Base classes from the button's current styling, excluding 'bottom-4' and 'md:bottom-8'.
+  // This preserves: fixed, right positioning, rounding, background, padding, text color,
+  // shadow, transition, hover, and focus states.
+  // Actual classes from previous file read:
+  // "fixed right-4 rounded-full bg-gray-800 p-3 text-white shadow-lg transition-all duration-300 ease-in-out hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-gray-500 focus:ring-opacity-50 md:right-8"
+  const baseClasses =
+    "fixed right-4 md:right-8 rounded-full bg-gray-800 p-3 text-white shadow-lg transition-all duration-300 ease-in-out hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-gray-500 focus:ring-opacity-50";
+
+  let positionClasses = "bottom-4 md:bottom-8"; // Default Tailwind classes for bottom positioning
+  let dynamicBottomStyle: React.CSSProperties = {};
+
+  if (isFooterIntersecting && footerHeight > 0) {
+    // Footer is intersecting, calculate dynamic bottom style
+    // The button's bottom edge should be `adjustmentMargin` above the footer's top edge.
+    dynamicBottomStyle = { bottom: `${footerHeight + adjustmentMargin}px` };
+    positionClasses = ""; // Remove Tailwind bottom classes to prevent conflict, inline style will take over.
+  }
+
   return (
     <button
+      type="button"
       onClick={scrollToTop}
-      className="fixed bottom-4 right-4 rounded-full bg-gray-800 p-3 text-white shadow-lg transition-all duration-300 ease-in-out hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-gray-500 focus:ring-opacity-50 md:bottom-8 md:right-8"
+      className={`${baseClasses} ${positionClasses}`.trim()} // .trim() to remove trailing space if positionClasses is empty
+      style={dynamicBottomStyle}
+      aria-label="ページトップへ戻る" // Matches the visually-hidden span for accessibility
     >
+      {/* Existing inline SVG icon */}
       <svg
         xmlns="http://www.w3.org/2000/svg"
         fill="none"

--- a/src/components/ScrollToTopButton.tsx
+++ b/src/components/ScrollToTopButton.tsx
@@ -51,6 +51,7 @@ const ScrollToTopButton = () => {
           d="M4.5 15.75l7.5-7.5 7.5 7.5"
         />
       </svg>
+      <span className="visually-hidden">ページトップへ戻る</span>
     </button>
   );
 };

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -5,7 +5,7 @@ import { ModeToggle } from "@/components/toggle-mode";
 
 export default function Footer() {
   return (
-    <footer className="mt-8 bg-gray-100 dark:bg-gray-800 py-6 px-4 md:px-6">
+    <footer id="site-footer" className="mt-8 bg-gray-100 dark:bg-gray-800 py-6 px-4 md:px-6">
       <div className="container mx-auto flex flex-col md:flex-row items-center justify-between gap-8">
         <div>
           <ModeToggle />


### PR DESCRIPTION
I've implemented a scroll-to-top button component that appears in the bottom-right corner of the page when you scroll down.

Features:
- The button is fixed to the bottom-right of the viewport.
- It appears only when you have scrolled more than 400px down the page.
- Clicking the button smoothly scrolls the page to the top.
- The button is styled with Tailwind CSS for a consistent look and feel, and includes hover and focus states.
- It is responsive and designed to be easily tappable on mobile devices.
- An upward arrow SVG icon is used to indicate the button's action.

The new component `ScrollToTopButton.tsx` has been added to `src/components/` and integrated into the main layout `src/app/layout.tsx` to ensure it is available on all pages.