### PR TITLE
feat: オペレーター表示順を改善

### DIFF
--- a/src/hooks/useFilterOperators.ts
+++ b/src/hooks/useFilterOperators.ts
@@ -8,6 +8,9 @@ import { isValidTag, type AllTag } from "@/lib/utils";
  * @param selectedItems - 選択されたタグ、タイプ、またはポジション
  * @returns - 選択された項目の組み合わせごとにグループ化されたフィルタリング結果
  */
+// type（職分）の並び順を定義
+const TYPE_ORDER = ["先鋒", "前衛", "重装", "狙撃", "術師", "医療", "補助", "特殊"];
+
 // 組み合わせ生成関数（フック外で定義）
 const generateCombinations = (items: string[]): string[][] => {
   const result: string[][] = [];
@@ -99,9 +102,18 @@ export const useFilterOperators = (
       const combinationKey = combination.join(" + ");
       const filtered = filterByCombination(combination);
 
-      // 結果が空でない場合のみ保存
+      // 結果が空でない場合のみ保存（レアリティ優先、次にtype順でソート）
       if (filtered.length > 0) {
-        results[combinationKey] = filtered;
+        results[combinationKey] = filtered.sort((a, b) => {
+          // レアリティで比較（優先）
+          if (a.rarity !== b.rarity) {
+            return a.rarity - b.rarity;
+          }
+          // レアリティが同じ場合はtype順で比較
+          const aTypeIndex = TYPE_ORDER.indexOf(a.type);
+          const bTypeIndex = TYPE_ORDER.indexOf(b.type);
+          return aTypeIndex - bTypeIndex;
+        });
       }
     });
 


### PR DESCRIPTION
## Summary
- 絞り込み結果を低レアリティから表示するように変更
- 同レアリティ内では職分順（先鋒→前衛→重装→狙撃→術師→医療→補助→特殊）で並び替え
- ユーザビリティ向上のため、より直感的な表示順序を実装

## Test plan
- [x] 絞り込み機能で複数のオペレーターが表示される条件でテスト
- [x] レアリティ順（低→高）で表示されることを確認
- [x] 同レアリティ内で職分順に表示されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)