### PR TITLE
chore: 依存の整理と optimize-json の説明統一

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "optimize-json:pretty": "node tools/optimize-json.js --pretty --indent=2"
   },
   "dependencies": {
-    "@next/bundle-analyzer": "15.1.7",
+    "@google-cloud/vision": "4.3.2",
     "@radix-ui/react-accordion": "1.2.3",
     "@radix-ui/react-avatar": "1.1.1",
     "@radix-ui/react-checkbox": "1.1.2",
@@ -26,6 +26,7 @@
     "@vercel/analytics": "1.4.1",
     "class-variance-authority": "0.7.1",
     "clsx": "2.1.1",
+    "fast-levenshtein": "^3.0.0",
     "lucide-react": "0.483.0",
     "next": "15.2.4",
     "next-themes": "0.3.0",
@@ -37,14 +38,13 @@
     "tailwindcss-animate": "1.0.7"
   },
   "devDependencies": {
-    "@google-cloud/vision": "4.3.2",
+    "@next/bundle-analyzer": "15.1.7",
     "@types/fast-levenshtein": "0.0.4",
     "@types/node": "22.9.3",
     "@types/react": "18.3.12",
     "@types/react-dom": "18.3.1",
     "eslint": "9.15.0",
     "eslint-config-next": "15.1.6",
-    "fast-levenshtein": "^3.0.0",
     "next-pwa": "5.6.0",
     "postcss": "8.4.49",
     "schema-dts": "1.1.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,9 @@ importers:
 
   .:
     dependencies:
-      '@next/bundle-analyzer':
-        specifier: 15.1.7
-        version: 15.1.7
+      '@google-cloud/vision':
+        specifier: 4.3.2
+        version: 4.3.2
       '@radix-ui/react-accordion':
         specifier: 1.2.3
         version: 1.2.3(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -50,6 +50,9 @@ importers:
       clsx:
         specifier: 2.1.1
         version: 2.1.1
+      fast-levenshtein:
+        specifier: ^3.0.0
+        version: 3.0.0
       lucide-react:
         specifier: 0.483.0
         version: 0.483.0(react@18.3.1)
@@ -78,9 +81,9 @@ importers:
         specifier: 1.0.7
         version: 1.0.7(tailwindcss@3.4.15)
     devDependencies:
-      '@google-cloud/vision':
-        specifier: 4.3.2
-        version: 4.3.2
+      '@next/bundle-analyzer':
+        specifier: 15.1.7
+        version: 15.1.7
       '@types/fast-levenshtein':
         specifier: 0.0.4
         version: 0.0.4
@@ -99,9 +102,6 @@ importers:
       eslint-config-next:
         specifier: 15.1.6
         version: 15.1.6(eslint@9.15.0(jiti@1.21.6))(typescript@5.7.2)
-      fast-levenshtein:
-        specifier: ^3.0.0
-        version: 3.0.0
       next-pwa:
         specifier: 5.6.0
         version: 5.6.0(@babel/core@7.26.7)(next@15.2.4(@babel/core@7.26.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(webpack@5.91.0)

--- a/tools/optimize-json.js
+++ b/tools/optimize-json.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 /**
- * Arknightsリクルートデータ最適化ツール
+ * 公開求人データ最適化
  *
  * 元のJSON形式を保持しながら余分な空白を除去して最適化します。
  * 元のファイルは保持され、最適化されたファイルは別名で保存されます。
@@ -24,7 +24,6 @@
  */
 
 const fs = require("node:fs");
-const path = require("node:path");
 
 // デフォルトのファイルパス
 const DEFAULT_INPUT_PATH = "./public/json/ak-recruit.json";
@@ -130,8 +129,6 @@ function parseArguments() {
 	};
 }
 
-// コマンドライン引数を処理
 const { inputPath, outputPath, options } = parseArguments();
 
-// 実行
 optimizeJson(inputPath, outputPath, options);

--- a/tools/optimize-json.js
+++ b/tools/optimize-json.js
@@ -7,12 +7,16 @@
  * 元のファイルは保持され、最適化されたファイルは別名で保存されます。
  *
  * 使用方法:
- * 1. 実行権限を付与: chmod +x scripts/optimize-json.js
- * 2. 実行: ./scripts/optimize-json.js [入力ファイル] [出力ファイル] [オプション]
+ * 1. 実行権限を付与: chmod +x tools/optimize-json.js
+ * 2. 直接実行: ./tools/optimize-json.js [入力ファイル] [出力ファイル] [オプション]
  *
  * 例:
- * ./scripts/optimize-json.js ./public/json/ak-recruit.json ./public/json/ak-recruit.min.json
- * ./scripts/optimize-json.js --pretty --indent=2
+ * ./tools/optimize-json.js ./public/json/ak-recruit.json ./public/json/ak-recruit.min.json
+ * ./tools/optimize-json.js --pretty --indent=2
+ *
+ * npm scripts からの実行例:
+ * npm run optimize-json
+ * npm run optimize-json:pretty
  *
  * オプション:
  * --pretty: 出力JSONに適切な改行とインデントを含めます


### PR DESCRIPTION
以下を対応しました。

- runtime依存を dependencies へ移動: @google-cloud/vision, fast-levenshtein
- build時のみの依存を devDependencies へ移動: @next/bundle-analyzer
- tools/optimize-json.js のコメント内パスを scripts→tools に修正
- npm scripts の実行例を追記

影響:
- ロックファイル更新が必要です（npm/pnpm install を実行してください）。

確認方法:
- npm run optimize-json
- npm run optimize-json:pretty
