### PR TITLE
フォント読み込みを調整してLCPを改善

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -59,6 +59,7 @@ const inter = Inter({
   display: "swap",
   variable: "--font-inter",
   preload: true,
+  fallback: ["system-ui", "sans-serif"]
 });
 /**
  * Google Fonts BIZ UDGothic
@@ -68,7 +69,9 @@ const biz = BIZ_UDGothic({
   subsets: ["latin"],
   display: "swap",
   variable: "--font-biz",
-  preload: true,
+  preload: false,
+  fallback: ["Hiragino Sans", "Noto Sans JP", "system-ui", "Yu Gothic", "Meiryo", "sans-serif"],
+  adjustFontFallback: false
 });
 
 export default function RootLayout({


### PR DESCRIPTION
## 概要
- Inter フォントにシステムフォールバックを追加して初期描画での無駄な再描画を防ぎました
- BIZ UDGothic の preload を無効化し、日本語フォールバックと adjustFontFallback=false を指定してフォント取得の待ち時間を短縮しました

## チェックリスト
- [x] npm run build
- [x] npm run lint
