### PR TITLE
feat: Open Graphと構造化データの拡充

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -33,6 +33,8 @@ export const metadata: Metadata = {
     title: "Arknights Recruitment | アークナイツ公開求人ツール",
     description:
       "アークナイツの公開求人機能をシミュレーションするWebツール 追加は実装日の16時に反映されます",
+    url: "/",
+    siteName: "Arknights Recruitment",
     images: "/img/icon.png?v=20251005-2",
   },
   twitter: {

--- a/src/components/json-ld.tsx
+++ b/src/components/json-ld.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import { WithContext, SoftwareApplication } from 'schema-dts';
 
 const JsonLd = () => {
+    const siteUrl = process.env.BASE_URL || 'http://localhost:3000';
+    const imageUrl = new URL('/img/icon.png?v=20251005-2', siteUrl).toString();
     const JsonLdData: WithContext<SoftwareApplication> = {
         "@context": "https://schema.org",
         "@type": "SoftwareApplication",
@@ -12,6 +14,9 @@ const JsonLd = () => {
             "price": "0"
         },
         "applicationCategory": "WebApplication",
+        "url": siteUrl,
+        "image": imageUrl,
+        "description": "アークナイツの公開求人機能をシミュレーションするWebツール 追加は実装日の16時に反映されます"
     }
 
     return (


### PR DESCRIPTION
## 概要
- Open Graph メタデータに `url` と `siteName` を追加し、プレビュー時のURL・ブランド名を統一
- SoftwareApplication スキーマに URL・画像・説明を加えて構造化データを拡充

## 影響範囲
- OG/Twitter カードに使用されるURLとサイト名
- 検索エンジン向けの構造化データ出力

## テスト
- `pnpm lint`
