### PR TITLE
fix: ハイドレーション前はタグ選択を空に維持

### DIFF
--- a/src/hooks/useCheckboxState.ts
+++ b/src/hooks/useCheckboxState.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from "react";
+import { useCallback, useMemo, useEffect, useState } from "react";
 import type { Dispatch, SetStateAction } from "react";
 import type { AllTag } from "@/lib/utils";
 import { allTags, isValidTag } from "@/lib/utils";
@@ -14,7 +14,19 @@ export const useCheckboxState = () => {
     selectedItemsParser
   );
 
-  const selectedItems = useMemo(() => selectedItemsRaw ?? [], [selectedItemsRaw]);
+  const [isHydrated, setIsHydrated] = useState(false);
+
+  useEffect(() => {
+    setIsHydrated(true);
+  }, []);
+
+  const selectedItems = useMemo(() => {
+    if (!isHydrated) {
+      return [] as AllTag[];
+    }
+
+    return selectedItemsRaw ?? [];
+  }, [isHydrated, selectedItemsRaw]);
 
   const checkedItems = useMemo(() => {
     return selectedItems.reduce<Record<string, boolean>>((acc, item) => {


### PR DESCRIPTION
## 概要
- ハイドレーション完了まではselectedItemsを空配列で扱うガードを追加
- Nuqs経由のURL同期はハイドレーション後に反映されるよう調整

## テスト
- pnpm lint
- pnpm build
