### PR TITLE
fix: /recommendからISR設定を削除

### DIFF
--- a/src/app/recommend/page.tsx
+++ b/src/app/recommend/page.tsx
@@ -8,9 +8,6 @@ export const metadata = {
 		"アークナイツの公開求人で星4以上のオペレーターを確実に入手できるタグ組み合わせを紹介します。",
 };
 
-// ISRの設定を追加
-export const revalidate = 86400; // 24時間ごとに再検証
-
 export default async function RecommendPage() {
 	const fs = require("fs");
 	const path = require("path");


### PR DESCRIPTION
## 概要
- /recommend ページから revalidate 指定を削除して常時静的配信に変更

## テスト
- 未実施（静的ページ設定の変更のみ）